### PR TITLE
Only show popular countries if search is empty

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -392,7 +392,7 @@ export const CountryList = ({
             style={[style?.itemsList]}
             keyboardShouldPersistTaps={'handled'}
             renderItem={renderItem}
-            ListHeaderComponent={(popularCountries && ListHeaderComponent) &&
+            ListHeaderComponent={(popularCountries && ListHeaderComponent && !searchValue ) &&
                 <ListHeaderComponent countries={preparedPopularCountries} lang={lang}/>}
             {...rest}
         />


### PR DESCRIPTION
Popular countries is visible when typing in search for countries, which doesn't make any sense.