### PR TITLE
feat: search by country name without diacritics

### DIFF
--- a/helpers/diacriticsRemover.ts
+++ b/helpers/diacriticsRemover.ts
@@ -1,0 +1,4 @@
+export const removeDiacritics = (text: string) => {
+    //get the unicode normalization form of the string and replace dialitics with empty string.
+    return text.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+  };

--- a/index.tsx
+++ b/index.tsx
@@ -15,6 +15,7 @@ import {CountryItem, ItemTemplateProps, Style, ListHeaderComponentProps} from ".
 import {useKeyboardStatus} from "./helpers/useKeyboardStatus";
 import {CountryButton} from "./components/CountryButton";
 import {countriesRemover} from "./helpers/countriesRemover";
+import { removeDiacritics } from './helpers/diacriticsRemover';
 
 export { countryCodes } from './constants/countryCodes'
 export {CountryButton} from "./components/CountryButton";
@@ -153,7 +154,10 @@ export const CountryPicker = ({
         const lowerSearchValue = searchValue.toLowerCase();
 
         return codes.filter((country) => {
-            if (country?.dial_code.includes(searchValue) || country?.name[lang || 'en'].toLowerCase().includes(lowerSearchValue)) {
+            if (country?.dial_code.includes(searchValue) || 
+                country?.name[lang || 'en'].toLowerCase().includes(lowerSearchValue) ||
+                removeDiacritics(country?.name[lang || 'en'].toLowerCase()).includes(lowerSearchValue)
+                ) {
                 return country;
             }
         });
@@ -374,7 +378,10 @@ export const CountryList = ({
         const lowerSearchValue = searchValue.toLowerCase();
 
         return codes.filter((country) => {
-            if (country?.dial_code.includes(searchValue) || country?.name[lang || 'en'].toLowerCase().includes(lowerSearchValue)) {
+            if (country?.dial_code.includes(searchValue) || 
+                country?.name[lang || 'en'].toLowerCase().includes(lowerSearchValue) ||
+                removeDiacritics(country?.name[lang || 'en'].toLowerCase()).includes(lowerSearchValue)
+                ) {
                 return country;
             }
         });


### PR DESCRIPTION
With the current behavior, you must type the country name including diacritics to find a result, which might cause a bad experience to the user:

![example](https://user-images.githubusercontent.com/36767059/236883248-9768b2f9-5ba2-4226-9917-c780b5217ddc.png)


With this feature the user will match the country with and without typing diacritics (e.g. both `"mex"` and `"méx"`  will match `"México"`)