### PR TITLE
Country update for KZ and KG

### DIFF
--- a/constants/countryCodes.ts
+++ b/constants/countryCodes.ts
@@ -3485,7 +3485,7 @@ export const countryCodes: CountryItem[] = [
             "tr": "Kazakistan",
             "hu": "Kazahsztán"
         },
-        "dial_code": "+77",
+        "dial_code": "+7",
         "code": "KZ",
         "flag": "🇰🇿"
     },
@@ -3653,7 +3653,7 @@ export const countryCodes: CountryItem[] = [
         "name": {
             "en": "Kyrgyzstan",
             "da": "Kyrgyzstan",
-            "ru": "Kyrgyzstan",
+            "ru": "Кыргызстан",
             "pl": "Kirgistan",
             "ua": "Киргизстан",
             "cz": "Kyrgyzstán",


### PR DESCRIPTION
fix: Added the russian locale for Kyrgyzstan (previously it was the same as english) now it has a russian translation, fixed dial code for Kazakhstan ( +77 -> +7 ). 