### PR TITLE
Rename 'la Suisse' to 'Suisse' for french

### DIFF
--- a/constants/countryCodes.ts
+++ b/constants/countryCodes.ts
@@ -6703,7 +6703,7 @@ export const countryCodes: CountryItem[] = [
             "ro": "Elveţia",
             "bg": "Швейцария",
             "de": "Schweiz",
-            "fr": "la Suisse",
+            "fr": "Suisse",
             "nl": "Zwitserland",
             "it": "Svizzera",
             "cn": "瑞士",


### PR DESCRIPTION
Hello !

Imo, it makes more sense in french to have 'Suisse' instead of 'la Suisse' in the picker.
'la Suisse' sound weird to me in this context.