### PR TITLE
Separated viewStyle and textStyle keys

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -437,9 +437,11 @@ export const CountryList = ({
 };
 
 
-type StyleKeys = 'container' | 'modal' | 'modalInner' | 'searchBar' | 'countryMessage' | 'line';
+type ViewStyleKeys = 'container' | 'modal' | 'modalInner' | 'countryMessage' | 'line';
+type TextStyleKeys = 'searchBar';
+type StylesType = { [key in ViewStyleKeys]: ViewStyle } & { [key in TextStyleKeys]: TextStyle };
 
-const styles: { [key in StyleKeys]: ViewStyle } = {
+const styles: StylesType = {
     container: {
         flex: 1,
         position: 'absolute',


### PR DESCRIPTION
Fix error of #111 .
In the expo project, a strict type error occurs.

`searchBar` needs to be strictly defined as `TextStyle`, and the rest of keys need to be defined as `ViewStyle`.

```
✖ tsc --project tsconfig.json --alwaysStrict:
node_modules/react-native-country-codes-picker/index.tsx(271,37): error TS2769: No overload matches this call.
  Overload 1 of 2, '(props: TextInputProps): TextInput', gave the following error.
    Type 'ViewStyle' is not assignable to type 'Falsy | TextStyle | RegisteredStyle<TextStyle> | RecursiveArray<Falsy | TextStyle | RegisteredStyle<TextStyle>> | readonly (Falsy | ... 1 more ... | RegisteredStyle<...>)[]'.
      Type 'ViewStyle' is not assignable to type 'TextStyle'.
        Types of property 'userSelect' are incompatible.
          Type 'string | undefined' is not assignable to type '"text" | "auto" | "none" | "contain" | "all" | undefined'.
            Type 'string' is not assignable to type '"text" | "auto" | "none" | "contain" | "all" | undefined'.
  Overload 2 of 2, '(props: TextInputProps, context: any): TextInput', gave the following error.
    Type 'ViewStyle' is not assignable to type 'Falsy | TextStyle | RegisteredStyle<TextStyle> | RecursiveArray<Falsy | TextStyle | RegisteredStyle<TextStyle>> | readonly (Falsy | ... 1 more ... | RegisteredStyle<...>)[]'.
      Type 'ViewStyle' is not assignable to type 'TextStyle'.
        Types of property 'userSelect' are incompatible.
          Type 'string | undefined' is not assignable to type '"text" | "auto" | "none" | "contain" | "all" | undefined'.
            Type 'string' is not assignable to type '"text" | "auto" | "none" | "contain" | "all" | undefined'.
```
<img width="686" alt="image" src="https://github.com/user-attachments/assets/f83e114d-7c1b-4107-9e23-2103253bd474" />
