### PR TITLE
Fix: Set search value to an empty string

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -187,6 +187,7 @@ export const CountryPicker = ({
     };
 
     const closeModal = () => {
+        setSearchValue('')
         Animated.timing(animationDriver, {
             toValue: 0,
             duration: 400,


### PR DESCRIPTION
## Description

This PR addresses the change to remove the search value on closing the modal for better UX.

## Screen Recordings

### Issue

https://github.com/user-attachments/assets/8186b46b-d363-480a-863d-d9249222169d

### Fix

https://github.com/user-attachments/assets/bd0d9819-8fe0-40da-af7f-06eabf9c62b8