### PR TITLE
Add support statusBarTranslucent for modal backdrop coverage

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -68,6 +68,7 @@ interface Props {
     searchMessage?: string,
     androidWindowSoftInputMode?: string,
     initialState?: string,
+    statusBarTranslucent?: boolean,
 }
 
 export const CountryPicker = ({
@@ -224,6 +225,7 @@ export const CountryPicker = ({
             visible={showModal}
             onShow={openModal}
             onRequestClose={onRequestClose}
+            statusBarTranslucent={statusBarTranslucent}
         >
             <View
                 style={{


### PR DESCRIPTION
Hi, I really like your library and find it very useful. However, while developing an app for Expo, I encountered a bug where the modal wasn't positioning itself correctly at the bottom. To fix it, I needed to apply the 'statusBarTranslucent' property to the modal. That's why I added that property.

 I'd appreciate it if you could accept the PR. 🙏

I've attached an image of what the bug looks like.

![image](https://github.com/user-attachments/assets/23290ca4-5a9f-4f01-bb39-b51589d3f9e5)
