### PR TITLE
fix: trim search input value and update license

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -158,10 +158,11 @@ export const CountryPicker = ({
     }, [showOnly, excludedCountries, lang]);
 
     const resultCountries = React.useMemo(() => {
-        const lowerSearchValue = searchValue.toLowerCase();
+        const lowerSearchValue = searchValue.toLowerCase().trim();
+        const searchDialCode = searchValue.trim();
 
         return codes.filter((country) => {
-            if (country?.dial_code.includes(searchValue) ||
+            if (country?.dial_code.includes(searchDialCode) ||
                 country?.name[lang || 'en'].toLowerCase().includes(lowerSearchValue) ||
                 removeDiacritics(country?.name[lang || 'en'].toLowerCase()).includes(lowerSearchValue)
             ) {
@@ -385,12 +386,13 @@ export const CountryList = ({
     }, [showOnly, excludedCountries]);
 
     const resultCountries = React.useMemo(() => {
-        const lowerSearchValue = searchValue.toLowerCase();
+        const lowerSearchValue = searchValue.toLowerCase().trim();
+        const searchDialCode = searchValue.trim();
 
         return codes.filter((country) => {
-            if (country?.dial_code.includes(searchValue) ||
-                country?.name[lang || 'en'].toLowerCase().includes(lowerSearchValue.trim()) ||
-                removeDiacritics(country?.name[lang || 'en'].toLowerCase()).includes(lowerSearchValue.trim())
+            if (country?.dial_code.includes(searchDialCode) ||
+                country?.name[lang || 'en'].toLowerCase().includes(lowerSearchValue) ||
+                removeDiacritics(country?.name[lang || 'en'].toLowerCase()).includes(lowerSearchValue)
             ) {
                 return country;
             }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "animated"
   ],
   "author": "George Hope",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/GeorgeHop/react-native-country-codes-picker/issues"
   },


### PR DESCRIPTION
## Summary
This PR addresses two minor issues. It trims the search value to prevent lookup failures caused by accidental trailing or leading spaces, and updates the package.json license field to reflect the actual MIT license.

## Problem
Closes #131
Closes #122

## Solution
- Added `.trim()` to the lowercase search value and dial code check in both filter locations.
- Changed `"license": "ISC"` to `"license": "MIT"` in package.json to match the `LICENSE` file.

## Checklist
- [x] Code builds without errors
- [x] Tests pass
- [x] No additional dependencies required